### PR TITLE
Update go mod pkg name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vincentwijaya/go-pkg
+module github.com/vincentwijaya/go-pkg/v1
 
 go 1.13
 


### PR DESCRIPTION
Update `go.mod` package name to match current github main branch major release version to prevent `v0.0.0-TIMESTAMP-COMMIT_HASH` in `go.sum`